### PR TITLE
perf: imporve kitty startup time

### DIFF
--- a/daemon/portal.py
+++ b/daemon/portal.py
@@ -83,7 +83,7 @@ REQUEST_XML = f"""
 # Priority order when nothing else identifies a terminal, and the table
 # `detect_terminal` checks $TERMINAL against.
 FALLBACK_TERMINALS = [
-    ["kitty", "--class", APP, "-e"],
+    ["kitty", "-1", "--wait-for-single-instance-window-close", "--class", APP, "-e"],
     ["ghostty", f"--class={APP}", "-e"],
     ["wezterm", "start", "--class", APP, "--"],
     ["foot", f"--app-id={APP}", "-e"],


### PR DESCRIPTION
```
     --single-instance [=no], -1 [=no]
            If specified only a single instance of kitty will run. New  invoca‐
            tions  will  instead  create a new top-level window in the existing
            kitty instance. This allows kitty to share a single sprite cache on
            the GPU and also reduces startup time. You can also  have  separate
            groups  of  kitty instances by using the kitty --instance-group op‐
            tion. You can use the kitty --start-as=hidden flag to start a back‐
            ground kitty instance that acts as a server.

     --wait-for-single-instance-window-close [=no]
            Normally, when using kitty --single-instance, kitty will open a new
            window  in an existing instance and quit immediately. With this op‐
            tion, it will not quit till the newly opened window is closed. Note
            that if no previous instance is found, then kitty will wait anyway,
            regardless of this option.

```

Actually I'm not sure if this will work well when there's no existing kitty instance.